### PR TITLE
Revise operation enum to contain counts

### DIFF
--- a/src/main/scala/bfcompiler/intermediate/IntermediateCompiler.scala
+++ b/src/main/scala/bfcompiler/intermediate/IntermediateCompiler.scala
@@ -70,7 +70,7 @@ object IntermediateCompiler:
                     pairingStack,
                     startIndexStack,
                     acc.addSimpleToken(
-                      OperationType.IncrementDataPointer,
+                      OperationType.IncrementDataPointer(1),
                       token.location
                     )
                   )
@@ -79,7 +79,7 @@ object IntermediateCompiler:
                     pairingStack,
                     startIndexStack,
                     acc.addSimpleToken(
-                      OperationType.DecrementDataPointer,
+                      OperationType.DecrementDataPointer(1),
                       token.location
                     )
                   )
@@ -88,7 +88,7 @@ object IntermediateCompiler:
                     pairingStack,
                     startIndexStack,
                     acc.addSimpleToken(
-                      OperationType.Increment,
+                      OperationType.Increment(1),
                       token.location
                     )
                   )
@@ -97,7 +97,7 @@ object IntermediateCompiler:
                     pairingStack,
                     startIndexStack,
                     acc.addSimpleToken(
-                      OperationType.Decrement,
+                      OperationType.Decrement(1),
                       token.location
                     )
                   )

--- a/src/main/scala/bfcompiler/intermediate/Operation.scala
+++ b/src/main/scala/bfcompiler/intermediate/Operation.scala
@@ -3,10 +3,10 @@ package bfcompiler.intermediate
 import bfcompiler.common.Location
 
 enum OperationType:
-  case IncrementDataPointer
-  case DecrementDataPointer
-  case Increment
-  case Decrement
+  case IncrementDataPointer(count: Int)
+  case DecrementDataPointer(count: Int)
+  case Increment(count: Int)
+  case Decrement(count: Int)
   case Write
   case Read
   case JumpForwardEqualZero(targetAddress: Int)

--- a/src/main/scala/bfcompiler/interpreter/Interpreter.scala
+++ b/src/main/scala/bfcompiler/interpreter/Interpreter.scala
@@ -18,25 +18,25 @@ object Interpreter:
       while (ip < program.ops.length)
         val operation = program.ops(ip)
         operation.op match
-          case OperationType.IncrementDataPointer =>
-            dp = dp + 1
+          case OperationType.IncrementDataPointer(count) =>
+            dp = dp + count
             if (dp >= data.length)
               return InterpreterError
                 .DataPointerOutOfBounds(dp, operation)
                 .asLeft
             ip = ip + 1
-          case OperationType.DecrementDataPointer =>
-            dp = dp - 1
+          case OperationType.DecrementDataPointer(count) =>
+            dp = dp - count
             if (dp < 0)
               return InterpreterError
                 .DataPointerOutOfBounds(dp, operation)
                 .asLeft
             ip = ip + 1
-          case OperationType.Increment =>
-            data(dp) = ((data(dp) + 1) % 255).toByte
+          case OperationType.Increment(count) =>
+            data(dp) = ((data(dp) + count) % 255).toByte
             ip = ip + 1
-          case OperationType.Decrement =>
-            data(dp) = ((data(dp) - 1) % 255).toByte
+          case OperationType.Decrement(count) =>
+            data(dp) = ((data(dp) - count) % 255).toByte
             ip = ip + 1
           case OperationType.Write =>
             println(data(dp))

--- a/src/main/scala/bfcompiler/native/NativeCompiler.scala
+++ b/src/main/scala/bfcompiler/native/NativeCompiler.scala
@@ -42,27 +42,27 @@ object NativeCompiler:
       val assembly = program.ops.zipWithIndex.map { case (op, ip) =>
         val address_label = s"addr_$ip:"
         val instructions = op.op match
-          case OperationType.IncrementDataPointer =>
+          case OperationType.IncrementDataPointer(count) =>
             s"""// Increment data pointer
                  |${pop("x0")}
-                 |add x0, x0, #1
+                 |add x0, x0, #$count
                  |${push("x0")}""".stripMargin
-          case OperationType.DecrementDataPointer =>
+          case OperationType.DecrementDataPointer(count) =>
             s"""// Decrement data pointer
                |${pop("x0")}
-               |sub x0, x0, #1
+               |sub x0, x0, #$count
                |${push("x0")}""".stripMargin
-          case OperationType.Increment =>
+          case OperationType.Increment(count) =>
             s"""// Increment
                |${getDPFromStack("x0")}
                |ldr x1, [x0]
-               |add x1, x1, #1
+               |add x1, x1, #$count
                |str x1, [x0]""".stripMargin
-          case OperationType.Decrement =>
+          case OperationType.Decrement(count) =>
             s"""// Decrement
                |${getDPFromStack("x0")}
                |ldr x1, [x0]
-               |sub x1, x1, #1
+               |sub x1, x1, #$count
                |str x1, [x0]""".stripMargin
           case OperationType.Write =>
             s"""// Write

--- a/src/test/scala/IntermediateCompilerSuite.scala
+++ b/src/test/scala/IntermediateCompilerSuite.scala
@@ -29,10 +29,10 @@ class IntermediateCompilerSuite extends munit.FunSuite:
       Validated.valid(
         Program(
           List(
-            Operation(OperationType.IncrementDataPointer, dummyLocation),
-            Operation(OperationType.DecrementDataPointer, dummyLocation),
-            Operation(OperationType.Increment, dummyLocation),
-            Operation(OperationType.Decrement, dummyLocation),
+            Operation(OperationType.IncrementDataPointer(1), dummyLocation),
+            Operation(OperationType.DecrementDataPointer(1), dummyLocation),
+            Operation(OperationType.Increment(1), dummyLocation),
+            Operation(OperationType.Decrement(1), dummyLocation),
             Operation(OperationType.Read, dummyLocation),
             Operation(OperationType.Write, dummyLocation),
             Operation(OperationType.JumpForwardEqualZero(7), dummyLocation),
@@ -56,7 +56,7 @@ class IntermediateCompilerSuite extends munit.FunSuite:
         Program(
           List(
             Operation(OperationType.JumpForwardEqualZero(2), dummyLocation),
-            Operation(OperationType.Increment, dummyLocation),
+            Operation(OperationType.Increment(1), dummyLocation),
             Operation(OperationType.JumpBackwardNotEqualZero(0), dummyLocation)
           )
         )
@@ -81,11 +81,11 @@ class IntermediateCompilerSuite extends munit.FunSuite:
         Program(
           List(
             Operation(OperationType.JumpForwardEqualZero(6), dummyLocation),
-            Operation(OperationType.Increment, dummyLocation),
+            Operation(OperationType.Increment(1), dummyLocation),
             Operation(OperationType.JumpForwardEqualZero(4), dummyLocation),
-            Operation(OperationType.Increment, dummyLocation),
+            Operation(OperationType.Increment(1), dummyLocation),
             Operation(OperationType.JumpBackwardNotEqualZero(2), dummyLocation),
-            Operation(OperationType.Increment, dummyLocation),
+            Operation(OperationType.Increment(1), dummyLocation),
             Operation(OperationType.JumpBackwardNotEqualZero(0), dummyLocation)
           )
         )


### PR DESCRIPTION
The `Operation` enum now keeps track of the `count` of an operation that might be repeated multiple times (e.g. `+` or `>`). 

This can later be used for optimization by collapsing `count` instructions of the same type into one.