### PR TITLE
Simple Optimizer

### DIFF
--- a/src/main/scala/bfcompiler/intermediate/Operation.scala
+++ b/src/main/scala/bfcompiler/intermediate/Operation.scala
@@ -11,6 +11,9 @@ enum OperationType:
   case Read
   case JumpForwardEqualZero(targetAddress: Int)
   case JumpBackwardNotEqualZero(targetAddress: Int)
-  case Noop
 
 case class Operation(op: OperationType, location: Location)
+
+object Operation:
+  extension (op: Operation)
+    def isSame(that: Operation): Boolean = op.op.ordinal == that.op.ordinal

--- a/src/main/scala/bfcompiler/interpreter/Interpreter.scala
+++ b/src/main/scala/bfcompiler/interpreter/Interpreter.scala
@@ -50,7 +50,5 @@ object Interpreter:
           case OperationType.JumpBackwardNotEqualZero(targetAddress) =>
             if (data(dp) != 0) ip = targetAddress + 1
             else ip = ip + 1
-          case OperationType.Noop =>
-            ip = ip + 1
 
       ().asRight

--- a/src/main/scala/bfcompiler/native/NativeCompiler.scala
+++ b/src/main/scala/bfcompiler/native/NativeCompiler.scala
@@ -98,7 +98,6 @@ object NativeCompiler:
                |ldr x1, [x0]
                |cbnz x1, addr_${targetAddress + 1}
                """.stripMargin
-          case OperationType.Noop => "nop"
 
         s"$address_label\n" + instructions.indent(4)
       }

--- a/src/main/scala/bfcompiler/optimizer/Optimizer.scala
+++ b/src/main/scala/bfcompiler/optimizer/Optimizer.scala
@@ -1,0 +1,59 @@
+package bfcompiler.optimizer
+
+import bfcompiler.common.Program
+import bfcompiler.intermediate.{Operation, OperationType}
+import bfcompiler.intermediate.Operation.*
+import bfcompiler.intermediate.OperationType.Increment
+import cats.data.{NonEmptyList}
+
+trait Optimizer:
+  def optimize(program: Program): Program
+
+object Optimizer:
+  private type CollapsableOperation = OperationType.Increment |
+    OperationType.Decrement | OperationType.IncrementDataPointer |
+    OperationType.DecrementDataPointer;
+
+  def default: Optimizer = new Optimizer:
+    private def collapseOperationGroup(
+        group: NonEmptyList[Operation]
+    ): Operation =
+      val count    = group.length
+      val location = group.head.location
+      group.head.op match
+        case _: OperationType.Increment =>
+          Operation(OperationType.Increment(count), location)
+        case _: OperationType.Decrement =>
+          Operation(OperationType.Decrement(count), location)
+        case _: OperationType.IncrementDataPointer =>
+          Operation(OperationType.IncrementDataPointer(count), location)
+        case _: OperationType.DecrementDataPointer =>
+          Operation(OperationType.DecrementDataPointer(count), location)
+        case _ =>
+          throw new IllegalStateException(
+            s"Can only collapse operations of type Increment, Decrement, IncrementDataPointeR and DecerementDataPointer but received ${group.head.op}."
+          )
+
+    private def collapseOperations(ops: List[Operation]): List[Operation] =
+      type Accumulator = (List[Operation], Option[NonEmptyList[Operation]])
+      val (collapsedOps, finalGroup) =
+        ops.foldLeft[Accumulator]((List.empty, None)) {
+          case ((processedOps, currentGroup), op) =>
+            currentGroup match
+              case Some(group) =>
+                if (group.head.isSame(op)) (processedOps, Some(group :+ op))
+                else
+                  val collasped = collapseOperationGroup(group)
+                  (processedOps :+ collasped :+ op, None)
+              case None =>
+                op.op match
+                  case _: CollapsableOperation =>
+                    (processedOps, Some(NonEmptyList.of(op)))
+                  case _ => (processedOps.appended(op), None)
+        }
+      finalGroup match
+        case Some(group) => collapsedOps :+ collapseOperationGroup(group)
+        case None        => collapsedOps
+
+    override def optimize(program: Program): Program =
+      Program(collapseOperations(program.ops))

--- a/src/test/scala/OptimizerSuite.scala
+++ b/src/test/scala/OptimizerSuite.scala
@@ -1,0 +1,78 @@
+import bfcompiler.common.{Location, Program}
+import bfcompiler.intermediate.OperationType.{Increment, Write}
+import bfcompiler.intermediate.{Operation, OperationType}
+import bfcompiler.optimizer.Optimizer
+
+class OptimizerSuite extends munit.FunSuite:
+  private val optimizer     = Optimizer.default
+  private val dummyLocation = Location.Local(0, 0)
+
+  private def makeRepeatedOp[T <: OperationType](
+      opTypeFactory: Int => T,
+      n: Int
+  ): List[Operation] =
+    List.fill(n)(Operation(opTypeFactory(1), dummyLocation))
+
+  private def testCollapse[T <: OperationType](
+      opTypeFactory: (count: Int) => T,
+      n: Int
+  ): Unit =
+    val ops       = makeRepeatedOp(opTypeFactory, n)
+    val collapsed = optimizer.optimize(Program(ops))
+    assertEquals(
+      collapsed.ops,
+      List(Operation(opTypeFactory(n), dummyLocation))
+    )
+
+  test("Optimizer collapses repeated increment operations correctly") {
+    testCollapse(OperationType.Increment.apply, 1)
+    testCollapse(OperationType.Increment.apply, 10)
+  }
+
+  test("Optimizer collapses repeated decrement operations correctly") {
+    testCollapse(OperationType.Decrement.apply, 1)
+    testCollapse(OperationType.Decrement.apply, 10)
+  }
+
+  test(
+    "Optimizer collapses repeated increment data pointer operations correctly"
+  ) {
+    testCollapse(OperationType.IncrementDataPointer.apply, 1)
+    testCollapse(OperationType.IncrementDataPointer.apply, 10)
+  }
+
+  test(
+    "Optimizer collapses repeated decrement data pointer operations correctly"
+  ) {
+    testCollapse(OperationType.DecrementDataPointer.apply, 1)
+    testCollapse(OperationType.DecrementDataPointer.apply, 10)
+  }
+
+  test("Optimizer does not affect non-collapsable ops") {
+    val ops = List(
+      Operation(OperationType.JumpBackwardNotEqualZero(0), dummyLocation),
+      Operation(OperationType.JumpForwardEqualZero(0), dummyLocation),
+      Operation(OperationType.Read, dummyLocation),
+      Operation(OperationType.Write, dummyLocation)
+    )
+    val collapsed = optimizer.optimize(Program(ops)).ops
+    assertEquals(collapsed, ops)
+  }
+
+  test("Optimizer collapses multiple groups of operations correctly") {
+    val ops = makeRepeatedOp(OperationType.Increment.apply, 3) ++ List(
+      Operation(OperationType.Write, dummyLocation)
+    ) ++ makeRepeatedOp(OperationType.Decrement.apply, 7) ++ List(
+      Operation(OperationType.Read, dummyLocation)
+    )
+    val collapsed = optimizer.optimize(Program(ops)).ops
+    assertEquals(
+      collapsed,
+      List(
+        Operation(OperationType.Increment(3), dummyLocation),
+        Operation(OperationType.Write, dummyLocation),
+        Operation(OperationType.Decrement(7), dummyLocation),
+        Operation(OperationType.Read, dummyLocation)
+      )
+    )
+  }


### PR DESCRIPTION
Implemented a simple optimizer to collapse repeated operations into a single one where possible. This affects:
 - Increment
 - Decrement
 - IncrementDataPointer
 - DecrementDataPointer

Also removed th `Noop` instruction.